### PR TITLE
Lawman Alert minor update

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -43,15 +43,19 @@ end)
 -- lawman alert
 --------------------------------------------------------------------------------------------------
 
-RegisterNetEvent('rsg-lawman:server:lawmanAlert', function(text)
+RegisterNetEvent('rsg-lawman:server:lawmanAlert', function(text, coords)
     local src = source
     local ped = GetPlayerPed(src)
-    local coords = GetEntityCoords(ped)
+    local pedCoords = GetEntityCoords(ped)
     local players = RSGCore.Functions.GetRSGPlayers()
 
     for _, v in pairs(players) do
         if v.PlayerData.job.type == 'leo' and v.PlayerData.job.onduty then
-            TriggerClientEvent('rsg-lawman:client:lawmanAlert', v.PlayerData.source, coords, text)
+            if coords then
+                TriggerClientEvent('rsg-lawman:client:lawmanAlert', v.PlayerData.source, coords, text)
+            else
+                TriggerClientEvent('rsg-lawman:client:lawmanAlert', v.PlayerData.source, pedCoords, text)
+            end
         end
     end
 end)


### PR DESCRIPTION
Updated lawmanAlert event/function to accept coords. Coords are optional - if not present, event defaults to previous behavior of using ped coords.

Useful for if the script writer would like to provide their own coords for the alert/blip location.